### PR TITLE
Multiple enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ cronmanager -c "/usr/bin/php /var/www/webdir/console broadcast:entities:updated 
 cronmanager -c "/usr/bin/python3 /path/to/python_script.py"
 ```
 
+Additional *-i* parameter adds sleep at the end of the process to let Prometheus to notice something is happening. It's going to sleep for 60 seconds minus anything that had happened before that. That means that if the command takes 20 seconds to finish the sleep at the end will be 40 seconds.
+
 # Options
 
 `-c`: The command to execute (required). This parameter is required. Please see the Usage section for caveats.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/abohmeed/cronmanager
+
+go 1.16
+
+require (
+	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b h1:FQ7+9fxhyp82ks9vAuyPzG0/vVbWwMwLJ+P6yJI5FN8=
+github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b/go.mod h1:HMcgvsgd0Fjj4XXDkbjdmlbI505rUPBs6WBMYg2pXks=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=


### PR DESCRIPTION
* Extra idle sleep to let prometheus to notice that something is happening.
* Add last dimension to the prometheus output to allow other tools
to check if the cronjob run at all.
* Ticker is moved at the beginning otherwise it didn't manage to write
duration when the command was too quick.
* We set dimension run to 1 a little bit earlier for the same reason.
* Change of default exporter path to /var/cache/prometheus/crons.prom
to close it to some Linux best practice.
* Set correct permissions of the crons.prom file.
* Add go.mod and go.sum so it can be build more easily.