### PR TITLE
create log file in append mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+cronmanager
+.idea

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/juju/fslock"
 )
 
-//isDelayed: Used to signal that the cron job delay was triggered
+// isDelayed: Used to signal that the cron job delay was triggered
 var (
 	isDelayed    = false
 	jobStartTime time.Time
@@ -90,7 +90,7 @@ func main() {
 
 	// If we have a log file specified, use it
 	if *logfilePtr != "" {
-		outfile, err := os.Create(*logfilePtr)
+		outfile, err := os.OpenFile(*logfilePtr, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Currently, the log file is truncated before writing, which means the history is lost everytime a cronjob runs though cronmanager. This PR writes to the file in append mode which is a more realistic production scenario